### PR TITLE
Update URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ You can use it to generate gigantic, continuous maps at a reasonable cost.
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/seezatnap/infinimap.git
-cd infinimap
+git clone https://github.com/seezatnap/nano-banana-infinimap
+cd nano-banana-infinimap
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
This pull request updates the repository references in the setup instructions of the `README.md` file to point to the correct GitHub repository. This ensures that users clone and work with the intended project.

* Updated the repository URL and directory name in the setup instructions to `nano-banana-infinimap` instead of `infinimap` in `README.md`.